### PR TITLE
Added user ID generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y libssl-dev
 
 RUN cd $HOME
 
-COPY ./lua_resty_netacea-0.0-4.rockspec ./
+COPY ./lua_resty_netacea-0.1-0.rockspec ./
 COPY ./src ./src
 
-RUN /usr/local/openresty/luajit/bin/luarocks make ./lua_resty_netacea-0.0-4.rockspec
+RUN /usr/local/openresty/luajit/bin/luarocks make ./lua_resty_netacea-0.1-0.rockspec

--- a/Dockerfile.nginx_lua
+++ b/Dockerfile.nginx_lua
@@ -8,7 +8,7 @@ USER root
 WORKDIR /usr/src
 
 ## Install required packages
-RUN yum update && yum install -y \
+RUN yum -y update && yum -y install \
     wget \
     gcc \
     gcc-c++ \
@@ -69,9 +69,9 @@ RUN cd /usr/src && \
     make install
 
 # Set up Netacea module
-COPY ./lua_resty_netacea-0.0-4.rockspec ./
+COPY ./lua_resty_netacea-0.1-0.rockspec ./
 COPY ./src ./src
-RUN luarocks make ./lua_resty_netacea-0.0-4.rockspec
+RUN luarocks make ./lua_resty_netacea-0.1-0.rockspec
 
 # Link CA certs so they match expected filename
 RUN ln -s /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # lua_resty_netacea
 An Openresty module for easy integration of Netacea services
 
+# Building the base image
+All the images used by docker rely on a specific base image being available on your local docker registry. You can ensure you have this by running the following command
+```sh
+docker build -t lua_resty_netacea:latest .
+```
+
 # Running Tests
 `docker-compose build` then `docker-compose run test`
 
@@ -29,14 +35,15 @@ http {
       secretKey          = 'your-secret-key',
       realIpHeader       = 'realip-header',
       ingestEnabled      = true,
-      mitigationEnabled  = true
+      mitigationEnabled  = true,
+      mitigationType     = 'MITIGATE'
     })
   }
   log_by_lua_block {
     netacea:ingest()
   }
   access_by_lua_block {
-    netacea:mitigate()
+    netacea:run()
   }
 
   server {
@@ -75,14 +82,15 @@ http {
       secretKey          = 'your-secret-key',
       realIpHeader       = 'realip-header',
       ingestEnabled      = true,
-      mitigationEnabled  = true
+      mitigationEnabled  = true,
+      mitigationType     = 'INJECT'
     })
   }
   log_by_lua_block {
     netacea:ingest()
   }
   access_by_lua_block {
-    netacea:inject()
+    netacea:run()
   }
 
   server {

--- a/lua_resty_netacea-0.1-0.rockspec
+++ b/lua_resty_netacea-0.1-0.rockspec
@@ -1,5 +1,5 @@
 package = "lua_resty_netacea"
-version = "0.0-4"
+version = "0.1-0"
 source = {
   url = "git://github.com/Netacea/lua_resty_netacea",
   branch = "master"

--- a/src/conf/nginx.conf
+++ b/src/conf/nginx.conf
@@ -22,7 +22,8 @@ http {
       secretKey          = '',
       realIpHeader       = '',
       ingestEnabled      = false,
-      mitigationEnabled  = false
+      mitigationEnabled  = false,
+      mitigationType     = ''
     })
   }
   log_by_lua_block {


### PR DESCRIPTION
When only ingest is enabled (or mitigation has been internally disabled due to misconfiguration), a `_mitata` cookie will still be set, and the user ID will have a `c` prefix.
Previously, in the above scenarios no cookie or user ID would be set