### PR TITLE
Fix build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      - name: Build Image
-        run: docker build --target test .
+      - name: Test
+        run: |
+          docker build --target test -t lua-resty-netacea-test .
+          docker run --rm lua-resty-netacea-test
       - name: Lint
-        run: docker build --target lint .
+        run: |
+          docker build --target lint -t lua-resty-netacea-lint .
+          docker run --rm lua-resty-netacea-lint
+      

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: lua-resty-netacea-build
-on: [push, pull_request]
+on: 
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Build Image
-        run: docker-compose build
+        run: docker build --target test .
       - name: Lint
-        run: docker-compose run lint
-      - name: Test
-        run: docker-compose run test
+        run: docker build --target lint .

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ CMD ["bash", "-c", "./run_lua_tests.sh"]
 
 FROM test AS lint
 
-CMD ["sh", "-c", "\"cd /usr/src && luacheck --no-self -- /usr/src\""]
+CMD ["bash", "-c", "luacheck --no-self -- ./src"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,0 @@
-FROM lua_resty_netacea:latest
-
-RUN /usr/local/openresty/luajit/bin/luarocks install busted
-RUN /usr/local/openresty/luajit/bin/luarocks install luacov
-RUN /usr/local/openresty/luajit/bin/luarocks install cluacov
-RUN /usr/local/openresty/luajit/bin/luarocks install require
-RUN /usr/local/openresty/luajit/bin/luarocks install luacheck

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,28 +16,22 @@ services:
 
   test:
     build:
-      dockerfile: Dockerfile.test
+      dockerfile: Dockerfile
       context: .
+      target: test
     volumes:
       - "./src:/usr/src/src"
       - "./test:/usr/src/test"
-      - "./run_lua_tests.sh:/usr/src/run_lua_tests.sh"
-    security_opt:
-      - seccomp:unconfined
-    command: bash -c '. /usr/src/run_lua_tests.sh -s; exit $$?'
 
   lint:
     build:
-      dockerfile: Dockerfile.test
+      dockerfile: Dockerfile
       context: .
+      target: lint
     volumes:
       - "./.luacheckrc:/usr/src/.luacheckrc"
       - "./src:/usr/src/src"
       - "./test:/usr/src/test"
-      - "./run_lua_tests.sh:/usr/src/run_lua_tests.sh"
-    security_opt:
-      - seccomp:unconfined
-    command: sh -c 'cd /usr/src && luacheck --no-self -- /usr/src'
 
   nginx_lua:
     build:

--- a/test/lua_resty_netacea.test.lua
+++ b/test/lua_resty_netacea.test.lua
@@ -2,10 +2,11 @@ require 'busted.runner'()
 
 package.path = "../src/?.lua;" .. package.path
 
-local runner = require 'luacov.runner'
-runner.tick = true
-runner.init({savestepsize = 3})
-jit.off()
+-- Temporarily disable luacov to check if it's causing the hang
+-- local runner = require 'luacov.runner'
+-- runner.tick = true
+-- runner.init({savestepsize = 3})
+-- jit.off()
 
 local COOKIE_DELIMITER = '_/@#/'
 

--- a/test/lua_resty_netacea.test.lua
+++ b/test/lua_resty_netacea.test.lua
@@ -2,7 +2,8 @@ require 'busted.runner'()
 
 package.path = "../src/?.lua;" .. package.path
 
--- Temporarily disable luacov to check if it's causing the hang
+-- luacov is disabled because this runner causes the test to hang after completion.
+-- Need to take another look at this in future.
 -- local runner = require 'luacov.runner'
 -- runner.tick = true
 -- runner.init({savestepsize = 3})


### PR DESCRIPTION
- Switch from docker-compose to multi-stage docker build to better support actions
- Remove coverage check which seems to cause the test script to hang at the end rather than quit out