### PR TITLE
chore(codefixer): apply code-scanning fixes

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI


### PR DESCRIPTION
## 🤖 Automated Codefixer PR

This PR was created by **netacea-codefixer**.

- Generated from: GitHub Compliance CodeScanningReport

## Summary
- Apply automated code-scanning fixes for Netacea/lua_resty_netacea.

## In this PR
- Automated replacements based on the code-scanning report.

## Checklist
- [x] CI Tests pass
- [x] Review the report summary below

## Next Steps
- Review the generated changes and run any repo-specific checks.

### Report Summary

# Codefixer Report: Netacea/lua_resty_netacea

- Status: completed
- Branch: fix/netacea-codefixer/0c50ab256f5a
- Base: master
- Hash: 0c50ab256f5a2bd512f2aaa1ada683d83b7e92b4c666688467e4296955ac1cb8
- Dry run: no
- Forced: yes
- Timestamp: 2026-02-04T15:09:11.099Z
- PR: #22

## Matches

- Total (filtered): 1
- Applied: 1
- Skipped: 0
- Note: survey-only matches (no replacement) are omitted.

## Results

| Severity | Status | File | Line | Match | Replace With | Reason |
| --- | --- | --- | --- | --- | --- | --- |
| 🟥 | applied | .github/workflows/codacy.yml | 39 | actions/checkout@v3 | actions/checkout@v4 |  |
